### PR TITLE
ARXIVNG-1422 integration with classic admin log

### DIFF
--- a/core/arxiv/submission/domain/agent.py
+++ b/core/arxiv/submission/domain/agent.py
@@ -72,11 +72,14 @@ class User(Agent):
     """An (human) end user."""
 
     email: str
+    username: str = field(default_factory=str)
     forename: str = field(default_factory=str)
     surname: str = field(default_factory=str)
     suffix: str = field(default_factory=str)
     identifier: Optional[str] = field(default=None)
     affiliation: str = field(default_factory=str)
+    hostname: Optional[str] = field(default=None)
+    """Hostname or IP address from which user requests are originating."""
 
     endorsements: List[str] = field(default_factory=list)
 
@@ -89,6 +92,7 @@ class User(Agent):
         """Generate a dict representation of this :class:`.User`."""
         data = super(User, self).to_dict()
         data['name'] = self.name
+        data['username'] = self.username
         data['forename'] = self.forename
         data['surname'] = self.surname
         data['suffix'] = self.suffix
@@ -109,6 +113,9 @@ class System(Agent):
 @dataclass
 class Client(Agent):
     """A non-human third party, usually an API client."""
+
+    hostname: Optional[str] = field(default_factory=None)
+    """Hostname or IP address from which client requests are originating."""
 
     def to_dict(self):
         """Generate a dict representation of this :class:`.Client` instance."""

--- a/core/arxiv/submission/domain/event/event.py
+++ b/core/arxiv/submission/domain/event/event.py
@@ -138,8 +138,6 @@ class Event:
         data.pop('after')
         return data
 
-
-
     @classmethod
     def bind(cls, condition: Optional[Condition] = None) -> Decorator:
         """

--- a/core/arxiv/submission/services/classic/__init__.py
+++ b/core/arxiv/submission/services/classic/__init__.py
@@ -312,7 +312,7 @@ def store_event(event: Event, before: Optional[Submission],
     session.add(dbs)
     session.add(db_event)
 
-    log.log(event, before, after)   # Generate admin log entry, if applicable.
+    log.handle(event, before, after)   # Create admin log entry, if applicable.
 
     # Attach the database object for the event to the row for the submission.
     if this_is_a_new_submission:    # Update in transaction.

--- a/core/arxiv/submission/services/classic/__init__.py
+++ b/core/arxiv/submission/services/classic/__init__.py
@@ -44,7 +44,7 @@ from .models import Base
 from .exceptions import ClassicBaseException, NoSuchSubmission, CommitFailed
 from .util import transaction, current_session
 from .event import DBEvent
-from . import models, util, interpolate
+from . import models, util, interpolate, log
 
 
 logger = logging.getLogger(__name__)
@@ -311,6 +311,8 @@ def store_event(event: Event, before: Optional[Submission],
     db_event = _new_dbevent(event)
     session.add(dbs)
     session.add(db_event)
+
+    log.log(event, before, after)   # Generate admin log entry, if applicable.
 
     # Attach the database object for the event to the row for the submission.
     if this_is_a_new_submission:    # Update in transaction.

--- a/core/arxiv/submission/services/classic/log.py
+++ b/core/arxiv/submission/services/classic/log.py
@@ -1,0 +1,70 @@
+"""Interface to the classic admin log."""
+
+from typing import Optional, Iterable
+
+from . import models, util
+from ...domain import event
+from ...domain.submission import Submission
+from ...domain.agent import Agent
+
+
+def log_unfinalize(event: event.UnFinalizeSubmission, before: Submission,
+                   after: Submission,) -> None:
+    """Create a log entry when a user pulls their submission for changes."""
+    admin_log(__name__, "unfinalize", "user has pulled submission for editing",
+              username=event.creator.username,
+              submission_id=after.submission_id,
+              paper_id=after.arxiv_id)
+
+
+LOG_EVENTS = {
+    event.UnFinalizeSubmission: log_unfinalize,
+}
+
+
+def log(event: event.Event, before: Submission, after: Submission) -> None:
+    """Generate an admin log entry for an event."""
+    if type(event) in LOG_EVENTS:
+        LOG_EVENTS[type(event)](event, before, after)
+
+
+def admin_log(program: str, command: str, text: str, notify: bool = False,
+              username: Optional[str] = None,
+              hostname: Optional[str] = None,
+              submission_id: Optional[int] = None,
+              paper_id: Optional[str] = None,
+              document_id: Optional[int] = None) -> None:
+    """
+    Add an entry to the admin log.
+
+    Parameters
+    ----------
+    program : str
+        Name of the application generating the log entry.
+    command : str
+        Name of the command generating the log entry.
+    text : str
+        Content of the admin log entry.
+    notify : bool
+    username : str
+    hostname : str
+        Hostname or IP address of the client.
+    submission_id : int
+    paper_id : str
+    document_id : int
+
+    """
+    with util.transaction() as session:
+        session.add(
+            models.AdminLogEntry(
+                paper_id=paper_id,
+                username=username,
+                host=hostname,
+                program=program,
+                command=command,
+                logtext=text,
+                document_id=document_id,
+                submission_id=submission_id,
+                notify=notify
+            )
+        )

--- a/core/arxiv/submission/services/classic/log.py
+++ b/core/arxiv/submission/services/classic/log.py
@@ -1,6 +1,6 @@
 """Interface to the classic admin log."""
 
-from typing import Optional, Iterable
+from typing import Optional, Iterable, Dict, Callable
 
 from . import models, util
 from ...domain import event
@@ -9,23 +9,40 @@ from ...domain.agent import Agent
 
 
 def log_unfinalize(event: event.UnFinalizeSubmission, before: Submission,
-                   after: Submission,) -> None:
+                   after: Submission) -> None:
     """Create a log entry when a user pulls their submission for changes."""
     admin_log(__name__, "unfinalize", "user has pulled submission for editing",
               username=event.creator.username,
+              hostname=event.creator.hostname,
               submission_id=after.submission_id,
               paper_id=after.arxiv_id)
 
 
-LOG_EVENTS = {
+ON_EVENT: Dict[type, Callable[[event.Event, Submission, Submission], None]] = {
     event.UnFinalizeSubmission: log_unfinalize,
 }
+"""Logging functions to call when an event is comitted."""
 
 
-def log(event: event.Event, before: Submission, after: Submission) -> None:
-    """Generate an admin log entry for an event."""
-    if type(event) in LOG_EVENTS:
-        LOG_EVENTS[type(event)](event, before, after)
+def handle(event: event.Event, before: Submission, after: Submission) -> None:
+    """
+    Generate an admin log entry for an event that is being committed.
+
+    Looks for a logging function in :ref:`.ON_EVENT` and, if found, calls it
+    with the passed parameters.
+
+    Parameters
+    ----------
+    event : :class:`event.Event`
+        The event being committed.
+    before : :class:`.Submission`
+        State of the submission before the event.
+    after : :class:`.Submission`
+        State of the submission after the event.
+
+    """
+    if type(event) in ON_EVENT:
+        ON_EVENT[type(event)](event, before, after)
 
 
 def admin_log(program: str, command: str, text: str, notify: bool = False,

--- a/core/arxiv/submission/services/classic/models.py
+++ b/core/arxiv/submission/services/classic/models.py
@@ -997,6 +997,43 @@ class Category(Base):    # type: ignore
                                server_default=text("'0'"))
 
 
+class AdminLogEntry(Base):    # type: ignore
+    """
+
+    +---------------+-----------------------+------+-----+-------------------+
+    | Field         | Type                  | Null | Key | Default           |
+    +---------------+-----------------------+------+-----+-------------------+
+    | id            | int(11)               | NO   | PRI | NULL              |
+    | logtime       | varchar(24)           | YES  |     | NULL              |
+    | created       | timestamp             | NO   |     | CURRENT_TIMESTAMP |  # on update CURRENT_TIMESTAMP
+    | paper_id      | varchar(20)           | YES  | MUL | NULL              |
+    | username      | varchar(20)           | YES  |     | NULL              |
+    | host          | varchar(64)           | YES  |     | NULL              |
+    | program       | varchar(20)           | YES  |     | NULL              |
+    | command       | varchar(20)           | YES  | MUL | NULL              |
+    | logtext       | text                  | YES  |     | NULL              |
+    | document_id   | mediumint(8) unsigned | YES  |     | NULL              |
+    | submission_id | int(11)               | YES  | MUL | NULL              |
+    | notify        | tinyint(1)            | YES  |     | 0                 |
+    +---------------+-----------------------+------+-----+-------------------+
+    """
+
+    __tablename__ = 'arXiv_admin_log'
+
+    id = Column(Integer, primary_key=True)
+    logtime = Column(String(24), nullable=True)
+    created = Column(DateTime, default=lambda: datetime.now(UTC))
+    paper_id = Column(String(20), nullable=True)
+    username = Column(String(20), nullable=True)
+    host = Column(String(64), nullable=True)
+    program = Column(String(20), nullable=True)
+    command = Column(String(20), nullable=True)
+    logtext = Column(Text, nullable=True)
+    document_id = Column(Integer, nullable=True)
+    submission_id = Column(Integer, nullable=True)
+    notify = Column(Integer, nullable=True, default=0)
+
+
 def _load_document(paper_id: str) -> Document:
     with transaction() as session:
         document = session.query(Document) \

--- a/core/arxiv/submission/services/classic/tests/__init__.py
+++ b/core/arxiv/submission/services/classic/tests/__init__.py
@@ -5,6 +5,7 @@ These tests assume that SQLAlchemy's MySQL backend is implemented correctly:
 instead of using a live MySQL database, they use an in-memory SQLite database.
 This is mostly fine (they are intended to be more-or-less swappable). The one
 iffy bit is the JSON datatype, which is not available by default in the SQLite
-backend, and so we inject a simple one here. End to end tests with a live MySQL
-database will provide more confidence in this area.
+backend. We extend the SQLite engine with a JSON type in 
+:mod:`arxiv.submission.services.classic.util`. End to end tests with a live 
+MySQL database will provide more confidence in this area.
 """

--- a/core/arxiv/submission/services/classic/tests/__init__.py
+++ b/core/arxiv/submission/services/classic/tests/__init__.py
@@ -1,0 +1,10 @@
+"""
+Integration tests for the classic database service.
+
+These tests assume that SQLAlchemy's MySQL backend is implemented correctly:
+instead of using a live MySQL database, they use an in-memory SQLite database.
+This is mostly fine (they are intended to be more-or-less swappable). The one
+iffy bit is the JSON datatype, which is not available by default in the SQLite
+backend, and so we inject a simple one here. End to end tests with a live MySQL
+database will provide more confidence in this area.
+"""

--- a/core/arxiv/submission/services/classic/tests/test_admin_log.py
+++ b/core/arxiv/submission/services/classic/tests/test_admin_log.py
@@ -1,0 +1,95 @@
+"""Tests for admin log integration."""
+
+from unittest import TestCase, mock
+import os
+from datetime import datetime
+from contextlib import contextmanager
+import json
+
+from flask import Flask
+
+from ....domain.agent import User, System
+from ....domain.submission import Submission, Author
+from ....domain.event import CreateSubmission, ConfirmPolicy, SetTitle
+from .. import models, store_event, log
+
+from .util import in_memory_db
+
+
+class TestAdminLog(TestCase):
+    """Test adding an admin long entry with :func:`.log.admin_log`."""
+
+    def test_add_admin_log_entry(self):
+        """Add a log entry."""
+        with in_memory_db() as session:
+            log.admin_log(
+                "fooprogram",
+                "test",
+                "this is a test of the admin log",
+                username="foouser",
+                hostname="127.0.0.1",
+                submission_id=5
+            )
+
+            logs = session.query(models.AdminLogEntry).all()
+            self.assertEqual(len(logs), 1)
+            self.assertEqual(logs[0].program, "fooprogram")
+            self.assertEqual(logs[0].command, "test")
+            self.assertEqual(logs[0].logtext,
+                             "this is a test of the admin log")
+            self.assertEqual(logs[0].username, "foouser")
+            self.assertEqual(logs[0].host, "127.0.0.1")
+            self.assertEqual(logs[0].submission_id, 5)
+            self.assertFalse(logs[0].notify)
+            self.assertIsNone(logs[0].document_id)
+            self.assertIsNone(logs[0].paper_id)
+
+
+class TestOnEvent(TestCase):
+    """Functions in :ref:`.log.ON_EVENT` are called."""
+
+    def test_on_event(self):
+        """Function in :ref:`.log.ON_EVENT` is called."""
+        mock_handler = mock.MagicMock()
+        log.ON_EVENT[ConfirmPolicy] = mock_handler
+        user = User(12345, 'joe@joe.joe', username="joeuser",
+                    endorsements=['physics.soc-ph', 'cs.DL'])
+        event = ConfirmPolicy(creator=user)
+        before = Submission(creator=user, owner=user, submission_id=42)
+        after = Submission(creator=user, owner=user, submission_id=42)
+        log.handle(event, before, after)
+        self.assertEqual(mock_handler.call_count, 1,
+                         "Handler registered for ConfirmPolicy is called")
+
+    def test_on_event_is_specific(self):
+        """Function in :ref:`.log.ON_EVENT` are specific."""
+        mock_handler = mock.MagicMock()
+        log.ON_EVENT[ConfirmPolicy] = mock_handler
+        user = User(12345, 'joe@joe.joe', username="joeuser",
+                    endorsements=['physics.soc-ph', 'cs.DL'])
+        event = SetTitle(creator=user, title="foo title")
+        before = Submission(creator=user, owner=user, submission_id=42)
+        after = Submission(creator=user, owner=user, submission_id=42)
+        log.handle(event, before, after)
+        self.assertEqual(mock_handler.call_count, 0,
+                         "Handler registered for ConfirmPolicy is not called")
+
+
+class TestStoreEvent(TestCase):
+    """Test log integration when storing event."""
+
+    def test_store_event(self):
+        """Log handler is called when an event is stored."""
+        mock_handler = mock.MagicMock()
+        log.ON_EVENT[CreateSubmission] = mock_handler
+        user = User(12345, 'joe@joe.joe', username="joeuser",
+                    endorsements=['physics.soc-ph', 'cs.DL'])
+        event = CreateSubmission(creator=user)
+        before = None
+        after = Submission(creator=user, owner=user, submission_id=42)
+
+        with in_memory_db():
+            store_event(event, before, after)
+
+        self.assertEqual(mock_handler.call_count, 1,
+                         "Handler registered for CreateSubmission is called")

--- a/core/arxiv/submission/services/classic/tests/test_get_licenses.py
+++ b/core/arxiv/submission/services/classic/tests/test_get_licenses.py
@@ -1,0 +1,44 @@
+"""Tests for retrieving license information."""
+
+from unittest import TestCase, mock
+
+from flask import Flask
+
+from ....domain.submission import License
+from .. import models, get_licenses
+from .util import in_memory_db
+
+
+class TestGetLicenses(TestCase):
+    """Test :func:`.get_licenses`."""
+
+    def test_get_all_active_licenses(self):
+        """Return a :class:`.License` for each active license in the db."""
+        # mock_util.json_factory.return_value = SQLiteJSON
+
+        with in_memory_db() as session:
+            session.add(models.License(
+                name="http://arxiv.org/licenses/assumed-1991-2003",
+                sequence=9,
+                label="Assumed arXiv.org perpetual, non-exclusive license to",
+                active=0
+            ))
+            session.add(models.License(
+                name="http://creativecommons.org/licenses/publicdomain/",
+                sequence=4,
+                label="Creative Commons Public Domain Declaration",
+                active=1
+            ))
+            session.commit()
+            licenses = get_licenses()
+
+        self.assertEqual(len(licenses), 1,
+                         "Only the active license should be returned.")
+        self.assertIsInstance(licenses[0], License,
+                              "Should return License instances.")
+        self.assertEqual(licenses[0].uri,
+                         "http://creativecommons.org/licenses/publicdomain/",
+                         "Should use name column to populate License.uri")
+        self.assertEqual(licenses[0].name,
+                         "Creative Commons Public Domain Declaration",
+                         "Should use label column to populate License.name")

--- a/core/arxiv/submission/services/classic/tests/test_get_submission.py
+++ b/core/arxiv/submission/services/classic/tests/test_get_submission.py
@@ -1,0 +1,152 @@
+"""Tests for retrieving submissions."""
+
+from unittest import TestCase, mock
+
+from flask import Flask
+
+from ....domain.agent import User, System
+from ....domain.submission import License, Submission, Author
+from ....domain.event import CreateSubmission, \
+    FinalizeSubmission, SetPrimaryClassification, AddSecondaryClassification, \
+    SetLicense, SetPrimaryClassification, ConfirmPolicy, \
+    ConfirmContactInformation, SetTitle, SetAbstract, SetDOI, \
+    SetMSCClassification, SetACMClassification, SetJournalReference, \
+    SetComments, SetAuthors, Publish, ConfirmAuthorship, ConfirmPolicy, \
+    SetUploadPackage
+from .. import init_app, create_all, drop_all, models, DBEvent, \
+    get_submission, current_session, get_licenses, exceptions, store_event
+
+from .util import in_memory_db
+
+
+class TestGetSubmission(TestCase):
+    """Test :func:`.get_submission`."""
+
+    def test_get_submission_that_does_not_exist(self):
+        """Test that an exception is raised when submission doesn't exist."""
+        with in_memory_db():
+            with self.assertRaises(exceptions.NoSuchSubmission):
+                get_submission(1)
+
+    def test_get_submission_with_publish(self):
+        """Test that publication state is reflected in submission data."""
+        user = User(12345, 'joe@joe.joe',
+                    endorsements=['physics.soc-ph', 'cs.DL'])
+
+        events = [
+            CreateSubmission(creator=user),
+            SetTitle(creator=user, title='Foo title'),
+            SetAbstract(creator=user, abstract='Indeed' * 10),
+            SetAuthors(creator=user, authors=[
+                Author(order=0, forename='Joe', surname='Bloggs',
+                       email='joe@blo.ggs'),
+                Author(order=1, forename='Jane', surname='Doe',
+                       email='j@doe.com'),
+            ]),
+            SetLicense(creator=user, license_uri='http://foo.org/1.0/',
+                       license_name='Foo zero 1.0'),
+            SetPrimaryClassification(creator=user, category='cs.DL'),
+            ConfirmPolicy(creator=user),
+            SetUploadPackage(creator=user, identifier='12345'),
+            ConfirmContactInformation(creator=user),
+            FinalizeSubmission(creator=user)
+        ]
+
+        with in_memory_db() as session:
+            # User creates and finalizes submission.
+            before = None
+            for i, event in enumerate(list(events)):
+                after = event.apply(before)
+                event, after = store_event(event, before, after)
+                events[i] = event
+                before = after
+            submission = after
+
+            ident = submission.submission_id
+
+            # Moderation happens, things change outside the event model.
+            db_submission = session.query(models.Submission).get(ident)
+
+            # Published!
+            db_submission.status = db_submission.PUBLISHED
+            db_document = models.Document(paper_id='1901.00123')
+            db_submission.document = db_document
+            session.add(db_submission)
+            session.add(db_document)
+            session.commit()
+
+            # Now get the submission.
+            submission_loaded, _ = get_submission(ident)
+
+        self.assertEqual(submission.metadata.title,
+                         submission_loaded.metadata.title,
+                         "Event-derived metadata should be preserved.")
+        self.assertEqual(submission_loaded.arxiv_id, "1901.00123",
+                         "arXiv paper ID should be set")
+        self.assertEqual(submission_loaded.status, Submission.PUBLISHED,
+                         "Submission status should reflect publish action")
+
+    def test_get_submission_with_hold_and_reclass(self):
+        """Test changes made externally are reflected in submission data."""
+        user = User(12345, 'joe@joe.joe',
+                    endorsements=['physics.soc-ph', 'cs.DL'])
+        events = [
+            CreateSubmission(creator=user),
+            SetTitle(creator=user, title='Foo title'),
+            SetAbstract(creator=user, abstract='Indeed' * 20),
+            SetAuthors(creator=user, authors=[
+                Author(order=0, forename='Joe', surname='Bloggs',
+                       email='joe@blo.ggs'),
+                Author(order=1, forename='Jane', surname='Doe',
+                       email='j@doe.com'),
+            ]),
+            SetLicense(creator=user, license_uri='http://foo.org/1.0/',
+                       license_name='Foo zero 1.0'),
+            SetPrimaryClassification(creator=user, category='cs.DL'),
+            ConfirmPolicy(creator=user),
+            SetUploadPackage(creator=user, identifier='12345'),
+            ConfirmContactInformation(creator=user),
+            FinalizeSubmission(creator=user)
+        ]
+
+        with in_memory_db() as session:
+            # User creates and finalizes submission.
+            before = None
+            for i, event in enumerate(list(events)):
+                after = event.apply(before)
+                event, after = store_event(event, before, after)
+                events[i] = event
+                before = after
+            submission = after
+            ident = submission.submission_id
+
+            # Moderation happens, things change outside the event model.
+            db_submission = session.query(models.Submission).get(ident)
+
+            # Reclassification!
+            session.delete(db_submission.primary_classification)
+            session.add(models.SubmissionCategory(
+                submission_id=ident, category='cs.IR', is_primary=1
+            ))
+
+            # On hold!
+            db_submission.status = db_submission.ON_HOLD
+            session.add(db_submission)
+            session.commit()
+
+            # Now get the submission.
+            submission_loaded, _ = get_submission(ident)
+
+        self.assertEqual(submission.metadata.title,
+                         submission_loaded.metadata.title,
+                         "Event-derived metadata should be preserved.")
+        self.assertEqual(submission_loaded.primary_classification.category,
+                         "cs.IR",
+                         "Primary classification should reflect the"
+                         " reclassification that occurred outside the purview"
+                         " of the event model.")
+        self.assertEqual(submission_loaded.status, Submission.ON_HOLD,
+                         "Submission status should still be submitted.")
+        self.assertTrue(submission_loaded.is_on_hold,
+                        "Hold status should reflect hold action performed"
+                        " outside the purview of the event model.")

--- a/core/arxiv/submission/services/classic/tests/test_store_event.py
+++ b/core/arxiv/submission/services/classic/tests/test_store_event.py
@@ -1,87 +1,21 @@
-"""
-Integration tests for the classic database service.
-
-These tests assume that SQLAlchemy's MySQL backend is implemented correctly:
-instead of using a live MySQL database, they use an in-memory SQLite database.
-This is mostly fine (they are intended to be more-or-less swappable). The one
-iffy bit is the JSON datatype, which is not available by default in the SQLite
-backend, and so we inject a simple one here. End to end tests with a live MySQL
-database will provide more confidence in this area.
-"""
+"""Tests for storing events."""
 
 from unittest import TestCase, mock
-import os
-from datetime import datetime
-from contextlib import contextmanager
-import json
 
 from flask import Flask
 
-from ...domain.agent import User, System
-from ...domain.submission import License, Submission, Author
-from ...domain.event import CreateSubmission, \
+from ....domain.agent import User, System
+from ....domain.submission import License, Submission, Author
+from ....domain.event import CreateSubmission, \
     FinalizeSubmission, SetPrimaryClassification, AddSecondaryClassification, \
-    SetLicense, SetPrimaryClassification, ConfirmPolicy, \
-    ConfirmContactInformation, SetTitle, SetAbstract, SetDOI, \
-    SetMSCClassification, SetACMClassification, SetJournalReference, \
-    SetComments, SetAuthors, Publish, ConfirmAuthorship, ConfirmPolicy, \
+    SetLicense, ConfirmPolicy, ConfirmContactInformation, SetTitle, \
+    SetAbstract, SetDOI, SetMSCClassification, SetACMClassification, \
+    SetJournalReference, SetComments, SetAuthors, Publish, ConfirmAuthorship, \
     SetUploadPackage
-from . import init_app, create_all, drop_all, models, DBEvent, \
+from .. import init_app, create_all, drop_all, models, DBEvent, \
     get_submission, current_session, get_licenses, exceptions, store_event
 
-
-@contextmanager
-def in_memory_db(app=None):
-    """Provide an in-memory sqlite database for testing purposes."""
-    if app is None:
-        app = Flask('foo')
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
-    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-
-    with app.app_context():
-        init_app(app)
-        create_all()
-        try:
-            yield current_session()
-        except Exception:
-            raise
-        finally:
-            drop_all()
-
-
-class TestGetLicenses(TestCase):
-    """Test :func:`.get_licenses`."""
-
-    def test_get_all_active_licenses(self):
-        """Return a :class:`.License` for each active license in the db."""
-        # mock_util.json_factory.return_value = SQLiteJSON
-
-        with in_memory_db() as session:
-            session.add(models.License(
-                name="http://arxiv.org/licenses/assumed-1991-2003",
-                sequence=9,
-                label="Assumed arXiv.org perpetual, non-exclusive license to",
-                active=0
-            ))
-            session.add(models.License(
-                name="http://creativecommons.org/licenses/publicdomain/",
-                sequence=4,
-                label="Creative Commons Public Domain Declaration",
-                active=1
-            ))
-            session.commit()
-            licenses = get_licenses()
-
-        self.assertEqual(len(licenses), 1,
-                         "Only the active license should be returned.")
-        self.assertIsInstance(licenses[0], License,
-                              "Should return License instances.")
-        self.assertEqual(licenses[0].uri,
-                         "http://creativecommons.org/licenses/publicdomain/",
-                         "Should use name column to populate License.uri")
-        self.assertEqual(licenses[0].name,
-                         "Creative Commons Public Domain Declaration",
-                         "Should use label column to populate License.name")
+from .util import in_memory_db
 
 
 class TestStoreEvent(TestCase):
@@ -358,136 +292,3 @@ class TestStoreEvent(TestCase):
         self.assertEqual(db_submission.primary_classification.category,
                          after.primary_classification.category,
                          "Primary classification should be set.")
-
-
-class TestGetSubmission(TestCase):
-    """Test :func:`.get_submission`."""
-
-    def test_get_submission_that_does_not_exist(self):
-        """Test that an exception is raised when submission doesn't exist."""
-        with in_memory_db():
-            with self.assertRaises(exceptions.NoSuchSubmission):
-                get_submission(1)
-
-    def test_get_submission_with_publish(self):
-        """Test that publication state is reflected in submission data."""
-        user = User(12345, 'joe@joe.joe',
-                    endorsements=['physics.soc-ph', 'cs.DL'])
-
-        events = [
-            CreateSubmission(creator=user),
-            SetTitle(creator=user, title='Foo title'),
-            SetAbstract(creator=user, abstract='Indeed' * 10),
-            SetAuthors(creator=user, authors=[
-                Author(order=0, forename='Joe', surname='Bloggs',
-                       email='joe@blo.ggs'),
-                Author(order=1, forename='Jane', surname='Doe',
-                       email='j@doe.com'),
-            ]),
-            SetLicense(creator=user, license_uri='http://foo.org/1.0/',
-                       license_name='Foo zero 1.0'),
-            SetPrimaryClassification(creator=user, category='cs.DL'),
-            ConfirmPolicy(creator=user),
-            SetUploadPackage(creator=user, identifier='12345'),
-            ConfirmContactInformation(creator=user),
-            FinalizeSubmission(creator=user)
-        ]
-
-        with in_memory_db() as session:
-            # User creates and finalizes submission.
-            before = None
-            for i, event in enumerate(list(events)):
-                after = event.apply(before)
-                event, after = store_event(event, before, after)
-                events[i] = event
-                before = after
-            submission = after
-
-            ident = submission.submission_id
-
-            # Moderation happens, things change outside the event model.
-            db_submission = session.query(models.Submission).get(ident)
-
-            # Published!
-            db_submission.status = db_submission.PUBLISHED
-            db_document = models.Document(paper_id='1901.00123')
-            db_submission.document = db_document
-            session.add(db_submission)
-            session.add(db_document)
-            session.commit()
-
-            # Now get the submission.
-            submission_loaded, _ = get_submission(ident)
-
-        self.assertEqual(submission.metadata.title,
-                         submission_loaded.metadata.title,
-                         "Event-derived metadata should be preserved.")
-        self.assertEqual(submission_loaded.arxiv_id, "1901.00123",
-                         "arXiv paper ID should be set")
-        self.assertEqual(submission_loaded.status, Submission.PUBLISHED,
-                         "Submission status should reflect publish action")
-
-    def test_get_submission_with_hold_and_reclass(self):
-        """Test changes made externally are reflected in submission data."""
-        user = User(12345, 'joe@joe.joe',
-                    endorsements=['physics.soc-ph', 'cs.DL'])
-        events = [
-            CreateSubmission(creator=user),
-            SetTitle(creator=user, title='Foo title'),
-            SetAbstract(creator=user, abstract='Indeed' * 20),
-            SetAuthors(creator=user, authors=[
-                Author(order=0, forename='Joe', surname='Bloggs',
-                       email='joe@blo.ggs'),
-                Author(order=1, forename='Jane', surname='Doe',
-                       email='j@doe.com'),
-            ]),
-            SetLicense(creator=user, license_uri='http://foo.org/1.0/',
-                       license_name='Foo zero 1.0'),
-            SetPrimaryClassification(creator=user, category='cs.DL'),
-            ConfirmPolicy(creator=user),
-            SetUploadPackage(creator=user, identifier='12345'),
-            ConfirmContactInformation(creator=user),
-            FinalizeSubmission(creator=user)
-        ]
-
-        with in_memory_db() as session:
-            # User creates and finalizes submission.
-            before = None
-            for i, event in enumerate(list(events)):
-                after = event.apply(before)
-                event, after = store_event(event, before, after)
-                events[i] = event
-                before = after
-            submission = after
-            ident = submission.submission_id
-
-            # Moderation happens, things change outside the event model.
-            db_submission = session.query(models.Submission).get(ident)
-
-            # Reclassification!
-            session.delete(db_submission.primary_classification)
-            session.add(models.SubmissionCategory(
-                submission_id=ident, category='cs.IR', is_primary=1
-            ))
-
-            # On hold!
-            db_submission.status = db_submission.ON_HOLD
-            session.add(db_submission)
-            session.commit()
-
-            # Now get the submission.
-            submission_loaded, _ = get_submission(ident)
-
-        self.assertEqual(submission.metadata.title,
-                         submission_loaded.metadata.title,
-                         "Event-derived metadata should be preserved.")
-        self.assertEqual(submission_loaded.primary_classification.category,
-                         "cs.IR",
-                         "Primary classification should reflect the"
-                         " reclassification that occurred outside the purview"
-                         " of the event model.")
-        self.assertEqual(submission_loaded.status, Submission.ON_HOLD,
-                         "Submission status should still be submitted.")
-        self.assertTrue(submission_loaded.is_on_hold,
-                        "Hold status should reflect hold action performed"
-                        " outside the purview of the event model.")

--- a/core/arxiv/submission/services/classic/tests/util.py
+++ b/core/arxiv/submission/services/classic/tests/util.py
@@ -1,0 +1,25 @@
+from contextlib import contextmanager
+
+from flask import Flask
+
+from .. import init_app, create_all, drop_all, models, DBEvent, \
+    get_submission, current_session, get_licenses, exceptions, store_event
+
+
+@contextmanager
+def in_memory_db(app=None):
+    """Provide an in-memory sqlite database for testing purposes."""
+    if app is None:
+        app = Flask('foo')
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+    with app.app_context():
+        init_app(app)
+        create_all()
+        try:
+            yield current_session()
+        except Exception:
+            raise
+        finally:
+            drop_all()


### PR DESCRIPTION
There are a few places during the submission process where we write to the "admin log", which is a table in the classic database. This implements writing to the admin log, and a simple hook mechanism for implementing writes to the log when an event is being stored.

This also led me to notice that we weren't representing the user's username in ``domain.agent.User``. We will also need the request hostname/IP address for various things (not just the admin log), so I added that, too. These are optional fields, so should not break anything downstream.