### PR TITLE
ARXIVNG-2013 stash submission content info in db

### DIFF
--- a/core/arxiv/submission/config.py
+++ b/core/arxiv/submission/config.py
@@ -82,7 +82,8 @@ BASE_SERVER = os.environ.get('BASE_SERVER', 'arxiv.org')
 SERVER_NAME = "submit.arxiv.org"
 
 URLS = [
-    ("submission", "/<int:submission_id>", "submit.arxiv.org")
+    ("submission", "/<int:submission_id>", "submit.arxiv.org"),
+    ("confirmation", "/<int:submission_id>/confirmation", "submit.arxiv.org")
 ]
 """
 URLs for external services, for use with :func:`flask.url_for`.

--- a/core/arxiv/submission/domain/__init__.py
+++ b/core/arxiv/submission/domain/__init__.py
@@ -2,7 +2,7 @@
 
 from .submission import Submission, License, SubmissionMetadata, \
     Classification, Author, Hold, WithdrawalRequest, UserRequest, \
-    CrossListClassificationRequest, Compilation
+    CrossListClassificationRequest, Compilation, SubmissionContent
 from .agent import User, System, Client, Agent, agent_factory
 from .event import event_factory, Event
 from .annotation import Comment

--- a/core/arxiv/submission/services/classic/load.py
+++ b/core/arxiv/submission/services/classic/load.py
@@ -131,6 +131,19 @@ def to_submission(row: models.Submission,
     secondary_clsn = [domain.Classification(category=db_cat.category)
                       for db_cat in row.categories if not db_cat.is_primary]
 
+    content: Optional[domain.SubmissionContent] = None
+    if row.package:
+        if row.package.startswith('fm://'):
+            identifier, checksum = row.package.split('://', 1)[1].split('@', 1)
+        else:
+            identifier = row.package
+        source_format = domain.SubmissionContent.Format(row.source_format)
+        content = domain.SubmissionContent(identifier=identifier,
+                                           compressed_size=0,
+                                           uncompressed_size=row.source_size,
+                                           checksum=checksum,
+                                           source_format=source_format)
+
     submission = domain.Submission(
         submission_id=submission_id,
         creator=submitter,
@@ -138,6 +151,7 @@ def to_submission(row: models.Submission,
         status=status,
         created=row.get_created(),
         updated=row.get_updated(),
+        source_content=content,
         submitter_is_author=bool(row.is_author),
         submitter_accepts_policy=bool(row.agree_policy),
         submitter_contact_verified=bool(row.userinfo),

--- a/core/arxiv/submission/services/classic/models.py
+++ b/core/arxiv/submission/services/classic/models.py
@@ -268,6 +268,8 @@ class Submission(Base):    # type: ignore
                     submission.source_content.source_format.value
             else:
                 self.source_format = None
+            self.package = (f'fm://{submission.source_content.identifier}'
+                            f'@{submission.source_content.checksum}')
 
         # Not submitted -> Submitted.
         if submission.finalized \

--- a/core/arxiv/submission/templates/submission-core/confirmation-email.html
+++ b/core/arxiv/submission/templates/submission-core/confirmation-email.html
@@ -2,12 +2,13 @@
 
 {% block email_title %}arXiv submission submit/{{ submission_id }}{% endblock email_title %}
 
-{% block message_title %}We have received your submission to arXiv.{% endblock message_title %}
+{% block message_title %}We have received your submission to arXiv, titled "{{ submission.metadata.title }}"{% endblock message_title %}
 
 {% block message_body %}
 <p style="margin: 0; margin-bottom: 15px;">
   Your temporary submission identifier is: <code>submit/{{ submission_id }}</code>.
-  You may update your submission at: <a href="{{ url_for("submission", submission_id=submission_id) }}">{{ url_for("submission", submission_id=submission_id) }}</a>.
+  To preview your submission, check the
+  <a href="{{ url_for('submission', submission_id=submission_id) }}">submission status page</a>.
 </p>
 
 <p style="margin: 0; margin-bottom: 15px;">
@@ -24,5 +25,4 @@
   contact <a href="mailto:{{ config.SUPPORT_EMAIL }}">{{ config.SUPPORT_EMAIL }}</a> with a
   description of the issue and reference the submission identifier.
 </p>
-
 {% endblock message_body %}

--- a/core/setup.py
+++ b/core/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-submission-core',
-    version='0.7.1rc3',
+    version='0.7.1rc4',
     packages=[f'arxiv.{package}' for package
               in find_packages('arxiv')],
     zip_safe=False,

--- a/core/setup.py
+++ b/core/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='arxiv-submission-core',
-    version='0.7.1rc4',
+    version='0.7.1rc5',
     packages=[f'arxiv.{package}' for package
               in find_packages('arxiv')],
     zip_safe=False,


### PR DESCRIPTION
Putting a temporary ref to the remote submission content in the ``package`` column, so that we can get it when loading directly from projected state.