### PR TITLE
Abstract paragraphs

### DIFF
--- a/core/arxiv/submission/domain/event/__init__.py
+++ b/core/arxiv/submission/domain/event/__init__.py
@@ -515,7 +515,6 @@ class SetAbstract(Event):
     @staticmethod
     def cleanup(value: str) -> str:
         """Perform some light tidying on the abstract."""
-        value = re.sub(r"\s+", " ", value)          # Single spaces only.
         value = value.strip()   # Remove leading or trailing spaces
         # Tidy paragraphs which should be indicated with "\n  ".
         value = re.sub(r"[ ]+\n", "\n", value)

--- a/core/arxiv/submission/domain/event/tests/test_abstract_cleanup.py
+++ b/core/arxiv/submission/domain/event/tests/test_abstract_cleanup.py
@@ -1,0 +1,52 @@
+"""Test abstract cleanup"""
+
+from unittest import TestCase
+from .. import SetAbstract
+from arxiv.base.filters import abstract_lf_to_br
+
+class TestSetAbstractCleanup(TestCase):
+    """Test abstract cleanup"""
+
+    def test_paragraph_cleanup(self):
+        awlb = "Paragraph 1.\n  \nThis should be paragraph 2"
+        self.assertIn('<br', abstract_lf_to_br(awlb),
+                      'sanity check: abstract filter does put <br> in')
+
+        e = SetAbstract(creator='xyz', abstract=awlb)
+        self.assertIn('<br', abstract_lf_to_br(e.abstract),
+                      '.cleanup must preserve <br> creating whitespace')
+
+        awlb = "Paragraph 1.\n\t\nThis should be p 2."
+        e = SetAbstract(creator='xyz', abstract=awlb)
+        self.assertIn('<br', abstract_lf_to_br(e.abstract),
+                      '.cleanup must preserve <br> creating whitespace (tab)')
+
+        awlb = "Paragraph 1.\n  \nThis should be p 2."
+        e = SetAbstract(creator='xyz', abstract=awlb)
+        self.assertIn('<br', abstract_lf_to_br(e.abstract),
+                      '.cleanup must preserve <br> creating whitespace')
+
+        awlb = "Paragraph 1.\n \t \nThis should be p 2."
+        e = SetAbstract(creator='xyz', abstract=awlb)
+        self.assertIn('<br', abstract_lf_to_br(e.abstract),
+                      '.cleanup must preserve <br> creating whitespace')
+
+        awlb = "Paragraph 1.\n     \nThis should be p 2."
+        e = SetAbstract(creator='xyz', abstract=awlb)
+        self.assertIn('<br', abstract_lf_to_br(e.abstract),
+                      '.cleanup must preserve <br> creating whitespace')
+
+        awlb = "Paragraph 1.\n This should be p 2."
+        e = SetAbstract(creator='xyz', abstract=awlb)
+        self.assertIn('<br', abstract_lf_to_br(e.abstract),
+                      '.cleanup must preserve <br> creating whitespace')
+
+        awlb = "Paragraph 1.\n\tThis should be p 2."
+        e = SetAbstract(creator='xyz', abstract=awlb)
+        self.assertIn('<br', abstract_lf_to_br(e.abstract),
+                      '.cleanup must preserve <br> creating whitespace')
+
+        awlb = "Paragraph 1.\n  This should be p 2."
+        e = SetAbstract(creator='xyz', abstract=awlb)
+        self.assertIn('<br', abstract_lf_to_br(e.abstract),
+                      '.cleanup must preserve <br> creating whitespace')


### PR DESCRIPTION
Changes SetAbstract.cleanup to preserve the sort of white space that will be end up as ```<br/>``` when the abstract is displayed. 

Adds tests.